### PR TITLE
Ajout des premiers tests

### DIFF
--- a/creationTEIheader.py
+++ b/creationTEIheader.py
@@ -1,0 +1,6 @@
+"""
+Création du TEIheader pour le catalogue d'exposition
+D'après un programme récupérant ces mêmes types d'informations réalisées par Claire Jahan
+Author: Juliette Janes
+Date: 18/06/21
+"""

--- a/extractionCatSimple.py
+++ b/extractionCatSimple.py
@@ -1,0 +1,120 @@
+"""
+Extraction des informations contenues dans les fichiers ALTO en sortie de l'OCR
+et insertion dans un fichier XML-TEI sur le modèle de l'ODD de Caroline Corbières
+
+Author: Juliette Janes
+Date: 11/06/21
+"""
+
+
+import re
+from lxml import etree as ET
+
+def extInfo_CatSimple(document):
+    """
+    Fonction permettant, pour un catalogue dit de typologie simple, c'est-à-dire ayant des entrées
+    où chaque ligne correspond à une information précise, d'extraire les différentes données contenues dans
+    le fichier alto et de les insérer dans un fichier tei
+    :param document: fichier alto parsé par etree
+    :type document: lxml.etree._ElementTree
+    :return: entrees_page
+    :rtype: list
+    """
+
+    # instanciation du namespace et de la liste finale
+    NS = {'alto': 'http://www.loc.gov/standards/alto/ns-v4#'}
+    entrees_page = []
+    n = 0
+    dict_entries = {}
+    tagref_entree = document.xpath("//alto:OtherTag[@LABEL='Entry']/@ID", namespaces=NS)
+    for entry in document.xpath("//alto:TextBlock[@TAGREFS='" + tagref_entree[0] + "']", namespaces=NS):
+        n += 1
+        texte_entry = entry.xpath("alto:TextLine/alto:String/@CONTENT", namespaces=NS)
+        dict_entries[n] = texte_entry
+
+    """relecture du texte contenu dans le dictionnaire entrée par entrée, extraction des données et 
+    intégration dans le xml"""
+    # instanciation des regex pour récupérer les auteurs et oeuvres (type de catalogue => Rouen 1850-1880)
+    auteur = re.compile(r'(^(\S[A-Z]{2,}))(.*?)(\.$)')
+    oeuvre = re.compile(r'^(\d{1,3}). \w')
+    # création de l'élément xml list
+    n_oeuvre = 0
+
+    for entry in dict_entries:
+        # Dans un premier temps on récupère l'emplacement de l'auteur et de la première oeuvre dans l'entrée
+        num = entry
+        text_list = dict_entries[num]
+        n_line = 0
+        n_line_oeuvre = 0
+        for ligne in text_list:
+            n_line += 1
+            if auteur.search(ligne):
+                n_line_auteur = n_line
+            elif oeuvre.search(ligne):
+                if n_line_oeuvre == 0:
+                    n_line_oeuvre = n_line
+            else:
+                pass
+
+        if n_line_auteur != 0 and n_line_oeuvre != 0:
+            # vérification que le textblock n'est pas vide et création des balises xml
+            root_entry_xml = ET.Element("entry")
+            desc_auteur_xml = ET.SubElement(root_entry_xml, "desc")
+            auteur_xml = ET.SubElement(desc_auteur_xml, "name")
+            trait_xml = ET.SubElement(desc_auteur_xml, "trait")
+
+            # récupération de la ligne auteur et de ou des lignes trait et intégration dans les balises xml
+            n = 0
+            liste_trait = []
+            dict_desc_item = {}
+            for ligne in text_list:
+                n += 1
+                if n == n_line_auteur:
+                    auteur_xml.text = ligne
+                elif n < n_line_oeuvre:
+                    liste_trait.append(ligne)
+                trait_str = "\n".join(liste_trait)
+                trait_xml.text = trait_str
+
+            # récupération des lignes oeuvres et potentielles lignes informations complémentaires sur l'oeuvre
+            # et intégration du titre de l'oeuvre et de son numéro dans l'arbre xml
+            for n in range(n_line_oeuvre - 1, len(text_list)):
+                if oeuvre.search(text_list[n]):
+                    item_xml = ET.SubElement(root_entry_xml, "item")
+                    num_xml = ET.SubElement(item_xml, "num")
+                    title_xml = ET.SubElement(item_xml, "title")
+                    n_oeuvre += 1
+                    num_xml.text = str(n_oeuvre)
+                    title_xml.text = re.sub(
+                        r'^\d{1,3}.', '', text_list[n])
+                    n_ligne_oeuvre = n
+                # si les lignes suivantes ne correspondent pas à une oeuvre, on considère qu'il s'agit d'une info
+                # et on les stockent donc ensemble sous la forme d'un dictionnaire où chaque clé correspond au
+                # numéro de l'oeuvre et chaque valeur aux lignes d'informations
+                elif n_ligne_oeuvre < n:
+                    if n_oeuvre in dict_desc_item:
+                        dict_desc_item[n_oeuvre] = [dict_desc_item[n_oeuvre], text_list[n]]
+                    else:
+                        dict_desc_item[n_oeuvre] = text_list[n]
+                        desc_item_xml = ET.SubElement(item_xml, "desc")
+                else:
+                    ('LIGNE NON RECONNUE: ', text_list[n])
+
+        # si le dictionnaire d'informations complémentaires est rempli, on insère ses valeurs dans l'arbre xml
+        if dict_desc_item:
+            desc_xml = root_entry_xml.xpath(".//desc/ancestor::item")
+            for el in desc_xml:
+                num_entree = el.xpath(".//num/text()")
+                num_entree_int = int("".join(num_entree))
+                desc_entree = el.find(".//desc")
+                texte_item_entry = str(dict_desc_item[num_entree_int])
+                texte_item_entry = texte_item_entry.replace("[['", "")
+                texte_item_entry = texte_item_entry.replace("', '", "")
+                texte_item_entry = texte_item_entry.replace("'], '", "")
+                texte_item_entry = texte_item_entry.replace("']", "")
+                desc_entree.text = texte_item_entry
+
+        # ajout de l'entrée réalisée dans la balise list
+        entrees_page.append(root_entry_xml)
+    return entrees_page
+

--- a/run.py
+++ b/run.py
@@ -1,0 +1,35 @@
+"""
+Initialisation du programme
+Programme permettant, à partir de catalogues d'expositions océrisés avec Kraken, d'extraire les données contenues
+dans le fichier de sortie de l'OCR, ALTO XML, et de construire un fichier TEI sur le modèle de l'ODD défini par
+Caroline Corbières (https://github.com/carolinecorbieres/ArtlasCatalogues/blob/master/5_ImproveGROBIDoutput/ODD/ODD_Transformation.xml)
+
+Author: Juliette Janes
+Date: 11/06/21
+"""
+from lxml import etree as ET
+import os
+from extractionCatSimple import extInfo_CatSimple
+
+
+
+# récupération du chemin
+dossier = input("Rentrer le dossier contenant les pages d'un même catalogue océsiré en alto XML 4: ")
+nom_fichier_tei = input("Rentrer le nom du fichier TEI en output: ")
+#création de la balise list contenant toutes les entrées du catalogue
+root_list_xml = ET.Element("list")
+
+for fichier in os.listdir(dossier):
+    # parsage du fichier
+    alto = ET.parse(dossier+fichier)
+    # création TEI header
+    # ici ajouter des tests pour vérifier la qualité de l'alto (cf le test.py)
+    # lancement de l'extraction des données du fichier
+    list_entrees = extInfo_CatSimple(alto)
+    # ajout des nouvelles entrées dans la balise liste
+    for el in list_entrees:
+        root_list_xml.append(el)
+
+# écriture du résultat dans un fichier xml
+ET.ElementTree(root_list_xml).write(nom_fichier_tei,encoding="UTF-8",xml_declaration=True)
+

--- a/test/test_Rouen_1860.xml
+++ b/test/test_Rouen_1860.xml
@@ -1,0 +1,619 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<alto xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns="http://www.loc.gov/standards/alto/ns-v4#"
+      xsi:schemaLocation="http://www.loc.gov/standards/alto/ns-v4# https://gitlab.inria.fr/scripta/escriptorium/-/raw/develop/app/escriptorium/static/alto-4-1-baselines.xsd">
+  <Description>
+    <MeasurementUnit>pixel</MeasurementUnit>
+    <sourceImageInformation>
+      <fileName>CatRouen_1860_bpt6k1181800p_24.JPEG</fileName>
+    </sourceImageInformation>
+  </Description>
+  
+  <Tags>
+    <OtherTag ID="BT457" LABEL="Figure" DESCRIPTION="block type Figure"/><OtherTag ID="BT458" LABEL="Main" DESCRIPTION="block type Main"/><OtherTag ID="BT459" LABEL="Numbering" DESCRIPTION="block type Numbering"/><OtherTag ID="BT461" LABEL="Running Title" DESCRIPTION="block type Running Title"/><OtherTag ID="BT462" LABEL="Stamp" DESCRIPTION="block type Stamp"/><OtherTag ID="BT463" LABEL="Title" DESCRIPTION="block type Title"/><OtherTag ID="BT464" LABEL="Entry" DESCRIPTION="block type Entry"/><OtherTag ID="BT465" LABEL="EntryEnd" DESCRIPTION="block type EntryEnd"/>
+    <OtherTag ID="LT168" LABEL="Default" DESCRIPTION="line type Default"/>
+  </Tags>
+  
+  <Layout>
+    <Page WIDTH="928"
+          HEIGHT="1566"
+          PHYSICAL_IMG_NR="20"
+          ID="eSc_dummypage_">
+      <PrintSpace HPOS="0"
+                  VPOS="0"
+                  WIDTH="928"
+                  HEIGHT="1566">
+        
+        <TextBlock HPOS="181"
+                   VPOS="208"
+                   WIDTH="565"
+                   HEIGHT="149"
+                   ID="eSc_textblock_2ebdddb0"
+                   TAGREFS="BT464">
+          <Shape><Polygon POINTS="535 208 726 222 729 246 746 257 736 261 746 264 739 350 208 357 181 343 181 257 198 226 535 208"/></Shape>
+          
+          
+          <TextLine ID="eSc_line_2aefdb92"
+                    TAGREFS="LT168"
+                    BASELINE="250 226 663 228 682 232" 
+                    HPOS="250"
+                    VPOS="194"
+                    WIDTH="432"
+                    HEIGHT="44">
+            <Shape><Polygon POINTS="250 226 252 208 268 194 282 198 288 194 328 196 334 200 342 196 345 200 359 196 363 200 383 200 391 207 401 199 407 203 420 197 430 202 438 199 449 207 459 203 468 207 476 203 479 207 491 205 502 196 516 207 532 197 551 196 565 206 582 202 604 207 615 203 625 211 680 211 682 232 671 238 650 238 645 233 611 233 602 236 597 233 591 236 577 234 573 238 559 234 553 238 537 234 527 237 522 234 515 237 476 237 464 232 446 237 390 234 368 236 363 233 358 236 321 236 316 231 251 230"/></Shape>
+	    <String CONTENT="(BÉNARD (AueusrE-SÉDAsrIEN)."
+                    HPOS="250"
+                    VPOS="194"
+                    WIDTH="432"
+                    HEIGHT="44"></String>
+          </TextLine>
+
+          
+          
+          <TextLine ID="eSc_line_17ba08ed"
+                    TAGREFS="LT168"
+                    BASELINE="202 261 725 261" 
+                    HPOS="202"
+                    VPOS="237"
+                    WIDTH="523"
+                    HEIGHT="48">
+            <Shape><Polygon POINTS="202 261 204 245 214 245 225 237 246 243 250 240 257 245 269 240 284 245 297 242 302 237 331 240 370 237 388 245 410 238 425 244 434 241 459 245 474 237 499 240 504 237 526 237 537 245 570 245 574 240 589 242 598 239 605 241 615 237 624 237 637 245 651 245 656 240 664 245 719 244 723 245 725 261 723 281 688 277 665 282 657 278 649 283 644 279 628 280 622 285 573 285 564 277 547 282 531 269 416 269 401 281 388 281 383 285 369 285 359 280 354 285 321 285 310 275 299 283 256 277 243 278 237 283 219 269 204 271"/></Shape>
+	    <String CONTENT="(APares, rue de Dufartune, 8, deue de Ml, Granet"
+                    HPOS="202"
+                    VPOS="237"
+                    WIDTH="523"
+                    HEIGHT="48"></String>
+          </TextLine>
+
+          
+          
+          <TextLine ID="eSc_line_13a15402"
+                    TAGREFS="LT168"
+                    BASELINE="412 281 519 283" 
+                    HPOS="412"
+                    VPOS="262"
+                    WIDTH="107"
+                    HEIGHT="27">
+            <Shape><Polygon POINTS="412 281 413 265 423 262 473 262 486 266 514 262 519 283 517 289 506 286 486 289 457 285 437 288 413 287"/></Shape>
+	    <String CONTENT="*et Lafond."
+                    HPOS="412"
+                    VPOS="262"
+                    WIDTH="107"
+                    HEIGHT="27"></String>
+          </TextLine>
+
+          
+          
+          <TextLine ID="eSc_line_299b5eee"
+                    TAGREFS="LT168"
+                    BASELINE="189 315 424 317" 
+                    HPOS="189"
+                    VPOS="286"
+                    WIDTH="235"
+                    HEIGHT="39">
+            <Shape><Polygon POINTS="189 315 191 294 204 290 211 294 250 294 268 287 275 293 283 286 296 286 302 287 309 294 329 294 336 294 342 287 371 287 385 294 396 288 403 291 423 287 424 317 413 321 353 320 341 325 308 325 291 321 280 323 275 320 250 324 240 319 234 324 214 324 209 320 202 322 190 319"/></Shape>
+	    <String CONTENT="34. Le Tombereau¬"
+                    HPOS="189"
+                    VPOS="286"
+                    WIDTH="235"
+                    HEIGHT="39"></String>
+          </TextLine>
+
+          
+          
+          <TextLine ID="eSc_line_c69f34f7"
+                    TAGREFS="LT168"
+                    BASELINE="195 351 492 349" 
+                    HPOS="195"
+                    VPOS="322"
+                    WIDTH="297"
+                    HEIGHT="39">
+            <Shape><Polygon POINTS="195 351 196 327 207 328 211 324 228 330 242 330 257 323 270 327 282 323 304 324 312 329 321 323 329 323 336 330 342 330 360 329 371 324 383 328 392 322 414 329 444 329 457 323 477 327 482 323 490 327 492 349 490 354 473 360 430 356 411 360 403 354 392 357 363 354 345 359 336 354 326 361 293 361 285 354 271 361 251 354 197 355"/></Shape>
+	    <String CONTENT="25. Le Rétour de la ville."
+                    HPOS="195"
+                    VPOS="322"
+                    WIDTH="297"
+                    HEIGHT="39"></String>
+          </TextLine>
+
+          
+        </TextBlock>
+        
+        <TextBlock HPOS="643"
+                   VPOS="208"
+                   WIDTH="37"
+                   HEIGHT="3"
+                   ID="eSc_textblock_2c690518"
+                   TAGREFS="BT464">
+          <Shape><Polygon POINTS="643 208 680 208 680 211 643 211 643 208"/></Shape>
+          
+        </TextBlock>
+        
+        <TextBlock HPOS="170"
+                   VPOS="407"
+                   WIDTH="590"
+                   HEIGHT="187"
+                   ID="eSc_textblock_001e8488"
+                   TAGREFS="BT464">
+          <Shape><Polygon POINTS="452 407 743 414 760 462 753 590 181 594 170 455 184 424 254 410 452 407"/></Shape>
+          
+          
+          <TextLine ID="eSc_line_5dfda26e"
+                    TAGREFS="LT168"
+                    BASELINE="273 432 655 435" 
+                    HPOS="273"
+                    VPOS="401"
+                    WIDTH="382"
+                    HEIGHT="41">
+            <Shape><Polygon POINTS="273 432 275 408 290 401 319 401 325 405 329 402 342 407 368 401 386 401 405 409 419 403 427 408 437 401 453 401 478 410 517 410 526 405 534 408 548 404 565 409 578 405 585 411 622 411 636 407 642 411 653 411 655 435 652 441 643 439 639 442 611 442 600 437 589 442 560 442 554 436 536 436 531 441 517 436 498 440 494 436 473 440 466 437 461 441 453 436 436 436 431 441 409 441 399 435 388 441 369 441 356 440 349 435 336 440 274 435"/></Shape>
+	    <String CONTENT="(BÉNARD (HupEnE-EGeÈNE)."
+                    HPOS="273"
+                    VPOS="401"
+                    WIDTH="382"
+                    HEIGHT="41"></String>
+          </TextLine>
+
+          
+          
+          <TextLine ID="eSc_line_2e32f57e"
+                    TAGREFS="LT168"
+                    BASELINE="176 464 749 466" 
+                    HPOS="176"
+                    VPOS="441"
+                    WIDTH="573"
+                    HEIGHT="37">
+            <Shape><Polygon POINTS="176 464 177 441 188 441 196 447 206 441 216 447 241 443 257 447 270 441 282 448 320 448 332 443 351 448 423 448 440 441 452 448 462 441 469 447 490 448 508 442 521 448 538 443 548 446 551 442 577 442 583 448 604 448 616 442 629 448 640 442 659 448 672 448 685 442 695 448 715 442 746 442 749 466 746 470 739 468 718 476 699 468 684 473 678 468 599 468 586 470 577 478 520 478 509 468 484 473 477 468 466 472 461 468 450 472 443 468 410 468 396 477 296 477 277 468 269 474 245 472 239 476 215 469 208 474 203 469 189 476 178 468"/></Shape>
+	    <String CONTENT="A Bouome-sur-Mer, poute de Calais, 5; dève de M. Claudin"
+                    HPOS="176"
+                    VPOS="441"
+                    WIDTH="573"
+                    HEIGHT="37"></String>
+          </TextLine>
+
+          
+          
+          <TextLine ID="eSc_line_2fc3554e"
+                    TAGREFS="LT168"
+                    BASELINE="410 487 518 487" 
+                    HPOS="410"
+                    VPOS="468"
+                    WIDTH="108"
+                    HEIGHT="26">
+            <Shape><Polygon POINTS="410 487 412 473 423 468 443 469 448 473 458 468 467 472 477 468 484 473 509 468 517 473 518 487 517 494 493 490 477 494 464 489 459 494 443 489 431 494 412 490"/></Shape>
+	    <String CONTENT="Jacquond."
+                    HPOS="410"
+                    VPOS="468"
+                    WIDTH="108"
+                    HEIGHT="26"></String>
+          </TextLine>
+
+          
+          
+          <TextLine ID="eSc_line_447c8db4"
+                    TAGREFS="LT168"
+                    BASELINE="186 519 685 521" 
+                    HPOS="186"
+                    VPOS="488"
+                    WIDTH="499"
+                    HEIGHT="40">
+            <Shape><Polygon POINTS="186 519 187 501 220 489 235 489 242 495 279 490 285 493 289 489 296 495 310 489 323 493 365 490 376 498 387 489 396 488 401 492 428 490 441 502 449 496 467 501 474 495 487 491 502 491 512 498 522 490 537 499 549 498 555 502 589 502 604 494 610 497 620 489 627 490 643 502 682 502 685 521 665 528 628 522 611 528 583 528 578 523 564 523 555 528 535 528 526 523 514 527 506 522 497 526 492 523 484 527 471 522 466 528 457 524 436 528 422 522 388 525 379 522 362 527 352 527 347 522 335 527 318 527 310 522 295 527 282 522 269 526 233 522 227 527 202 527 187 522"/></Shape>
+	    <String CONTENT="26. La Brise en rade de Boulogne-sur-Mer¬"
+                    HPOS="186"
+                    VPOS="488"
+                    WIDTH="499"
+                    HEIGHT="40"></String>
+          </TextLine>
+
+          
+          
+          <TextLine ID="eSc_line_40fe901a"
+                    TAGREFS="LT168"
+                    BASELINE="188 556 749 556" 
+                    HPOS="188"
+                    VPOS="533"
+                    WIDTH="561"
+                    HEIGHT="33">
+            <Shape><Polygon POINTS="188 556 189 535 198 533 217 534 226 539 239 538 244 533 268 533 279 539 303 539 315 535 321 539 337 539 344 533 357 539 365 539 371 533 423 533 431 539 477 539 488 533 501 539 512 539 519 533 531 533 540 539 568 538 577 533 605 533 617 539 675 539 690 533 705 539 746 536 749 556 741 566 704 566 698 562 685 566 622 566 608 562 571 562 562 566 557 562 545 566 542 562 484 562 480 566 465 562 453 566 435 562 428 566 419 562 404 566 357 562 342 562 338 566 320 562 305 562 302 566 279 562 272 566 235 562 189 564"/></Shape>
+	    <String CONTENT="57. Barque de Pécheurs du Portel, levant l’ancr."
+                    HPOS="188"
+                    VPOS="533"
+                    WIDTH="561"
+                    HEIGHT="33"></String>
+          </TextLine>
+
+          
+          
+          <TextLine ID="eSc_line_215aa05d"
+                    TAGREFS="LT168"
+                    BASELINE="296 568 308 568" 
+                    HPOS="296"
+                    VPOS="562"
+                    WIDTH="10"
+                    HEIGHT="9">
+            <Shape><Polygon POINTS="296 568 306 562 306 571 298 568"/></Shape>
+	    <String CONTENT="2e"
+                    HPOS="296"
+                    VPOS="562"
+                    WIDTH="10"
+                    HEIGHT="9"></String>
+          </TextLine>
+
+          
+          
+          <TextLine ID="eSc_line_9f957ec6"
+                    TAGREFS="LT168"
+                    BASELINE="322 568 457 568" 
+                    HPOS="322"
+                    VPOS="563"
+                    WIDTH="135"
+                    HEIGHT="5">
+            <Shape><Polygon POINTS="322 568 324 565 341 563 436 563 457 568 324 568"/></Shape>
+	    <String CONTENT="1-222"
+                    HPOS="322"
+                    VPOS="563"
+                    WIDTH="135"
+                    HEIGHT="5"></String>
+          </TextLine>
+
+          
+          
+          <TextLine ID="eSc_line_48f89814"
+                    TAGREFS="LT168"
+                    BASELINE="274 586 593 583" 
+                    HPOS="274"
+                    VPOS="563"
+                    WIDTH="319"
+                    HEIGHT="32">
+            <Shape><Polygon POINTS="274 586 275 565 294 565 310 580 378 580 398 575 403 579 423 579 433 571 445 569 449 573 460 565 475 569 485 563 504 568 522 563 557 568 577 563 585 571 591 569 593 583 588 590 579 589 575 594 549 588 544 591 536 588 531 594 504 590 486 595 450 595 442 589 434 595 408 595 404 591 393 594 380 588 356 595 337 595 332 592 329 595 322 589 289 589 275 595"/></Shape>
+	    <String CONTENT="Dar N2Ds vemps (marine)."
+                    HPOS="274"
+                    VPOS="563"
+                    WIDTH="319"
+                    HEIGHT="32"></String>
+          </TextLine>
+
+          
+        </TextBlock>
+        
+        <TextBlock HPOS="167"
+                   VPOS="636"
+                   WIDTH="590"
+                   HEIGHT="455"
+                   ID="eSc_textblock_31d74850"
+                   TAGREFS="BT464">
+          <Shape><Polygon POINTS="208 636 743 643 757 682 753 1067 666 1091 590 1074 188 1070 167 928 167 685 174 657 208 636"/></Shape>
+          
+          
+          <TextLine ID="eSc_line_7499d865"
+                    TAGREFS="LT168"
+                    BASELINE="332 663 595 666" 
+                    HPOS="332"
+                    VPOS="634"
+                    WIDTH="263"
+                    HEIGHT="41">
+            <Shape><Polygon POINTS="332 663 336 636 359 638 371 634 403 639 475 634 493 638 507 635 516 642 533 642 548 635 567 635 578 642 593 642 595 666 588 674 582 675 564 675 558 670 545 675 522 675 516 670 486 669 477 674 449 670 440 674 435 669 420 674 387 669 368 669 363 673 333 669"/></Shape>
+	    <String CONTENT="(BENNETTER (J.)."
+                    HPOS="332"
+                    VPOS="634"
+                    WIDTH="263"
+                    HEIGHT="41"></String>
+          </TextLine>
+
+          
+          
+          <TextLine ID="eSc_line_7afd2d3a"
+                    TAGREFS="LT168"
+                    BASELINE="174 697 746 702" 
+                    HPOS="174"
+                    VPOS="671"
+                    WIDTH="572"
+                    HEIGHT="35">
+            <Shape><Polygon POINTS="174 697 175 677 205 677 215 672 223 677 232 673 236 677 254 677 262 673 268 677 306 678 314 673 325 678 347 678 351 675 362 678 376 675 383 678 398 671 415 679 423 679 432 672 468 678 479 672 500 672 511 679 525 674 538 679 553 673 571 679 592 673 633 681 660 674 680 674 689 678 699 678 703 674 744 674 746 702 721 706 707 702 700 706 665 706 659 702 648 706 625 701 581 701 572 705 560 701 548 704 531 701 524 705 514 700 503 704 474 700 415 704 395 699 382 702 371 699 366 703 349 700 342 703 300 700 254 702 249 698 243 702 180 702 175 699"/></Shape>
+	    <String CONTENT="(Deintre de marine à Paris, rue du Faubourg-Saint-Honoré, 217."
+                    HPOS="174"
+                    VPOS="671"
+                    WIDTH="572"
+                    HEIGHT="35"></String>
+          </TextLine>
+
+          
+          
+          <TextLine ID="eSc_line_4a811abc"
+                    TAGREFS="LT168"
+                    BASELINE="274 718 647 722" 
+                    HPOS="274"
+                    VPOS="700"
+                    WIDTH="373"
+                    HEIGHT="29">
+            <Shape><Polygon POINTS="274 718 275 703 293 700 308 703 341 703 345 700 354 703 376 700 382 703 394 700 415 704 430 700 454 704 459 700 484 705 532 705 537 701 553 701 567 706 581 702 637 702 645 704 647 722 641 728 613 724 599 729 581 729 576 725 567 729 538 729 528 723 517 723 510 729 498 724 487 729 469 729 460 722 445 728 432 728 426 722 388 725 360 722 355 727 337 727 334 723 289 727 275 722"/></Shape>
+	    <String CONTENT=" élève de MM. L. Meuer et 1. Gudin."
+                    HPOS="274"
+                    VPOS="700"
+                    WIDTH="373"
+                    HEIGHT="29"></String>
+          </TextLine>
+
+          
+          
+          <TextLine ID="eSc_line_cb553434"
+                    TAGREFS="LT168"
+                    BASELINE="186 751 410 754" 
+                    HPOS="186"
+                    VPOS="727"
+                    WIDTH="224"
+                    HEIGHT="37">
+            <Shape><Polygon POINTS="186 751 188 735 198 728 212 729 218 735 240 735 247 728 260 727 277 728 283 734 303 734 315 728 326 733 345 729 356 735 371 736 376 731 390 736 408 736 410 754 399 762 380 760 373 764 316 763 308 760 305 762 299 757 261 763 243 762 237 756 208 756 196 762 187 762"/></Shape>
+	    <String CONTENT="58. Fffet de Lune."
+                    HPOS="186"
+                    VPOS="727"
+                    WIDTH="224"
+                    HEIGHT="37"></String>
+          </TextLine>
+
+          
+          
+          <TextLine ID="eSc_line_9c9833d3"
+                    TAGREFS="LT168"
+                    BASELINE="191 783 493 787 742 783" 
+                    HPOS="191"
+                    VPOS="764"
+                    WIDTH="551"
+                    HEIGHT="25">
+            <Shape><Polygon POINTS="191 783 193 769 207 764 221 769 273 769 279 764 302 769 322 765 329 768 335 764 364 764 376 769 444 769 454 764 478 764 484 769 496 764 517 768 522 765 525 769 545 765 558 769 597 769 607 764 624 764 634 769 658 764 664 769 699 769 708 764 739 764 742 783 739 789 732 789 708 789 702 786 684 789 634 789 621 786 616 789 570 789 559 786 534 789 193 787"/></Shape>
+	    <String CONTENT="(Une escadre venant en grande large; le prémier plan repré"
+                    HPOS="191"
+                    VPOS="764"
+                    WIDTH="551"
+                    HEIGHT="25"></String>
+          </TextLine>
+
+          
+          
+          <TextLine ID="eSc_line_7d957793"
+                    TAGREFS="LT168"
+                    BASELINE="177 804 745 807" 
+                    HPOS="177"
+                    VPOS="787"
+                    WIDTH="568"
+                    HEIGHT="25">
+            <Shape><Polygon POINTS="177 804 181 788 274 790 301 787 308 790 348 790 355 787 379 791 402 788 407 791 421 788 430 791 438 788 449 791 455 788 481 791 490 788 497 791 558 789 561 792 567 789 571 792 582 789 601 792 613 792 617 789 644 792 654 789 664 792 673 789 687 792 699 789 712 792 737 789 743 792 745 807 742 812 730 809 614 809 602 812 590 809 523 811 517 808 503 808 499 811 416 811 411 808 406 811 352 808 323 810 320 807 179 809"/></Shape>
+	    <String CONTENT="(sente un navire marchant (brick), louvovant et virant de bord."
+                    HPOS="177"
+                    VPOS="787"
+                    WIDTH="568"
+                    HEIGHT="25"></String>
+          </TextLine>
+
+          
+          
+          <TextLine ID="eSc_line_dccf32fd"
+                    TAGREFS="LT168"
+                    BASELINE="176 827 652 829" 
+                    HPOS="176"
+                    VPOS="809"
+                    WIDTH="476"
+                    HEIGHT="27">
+            <Shape><Polygon POINTS="176 827 180 809 202 812 209 809 215 812 228 812 231 809 258 809 262 812 281 812 284 809 392 812 403 809 416 813 448 813 452 809 467 813 484 809 494 813 501 809 510 813 549 813 552 809 560 813 569 809 623 813 626 809 638 809 649 813 652 829 649 836 618 836 611 831 603 836 596 829 577 829 564 836 541 835 535 829 515 829 511 833 478 833 470 829 463 833 450 829 444 834 416 836 402 829 382 829 372 835 359 829 273 835 264 829 254 834 241 829 235 832 226 829 219 835 202 830 197 835 190 829 177 835"/></Shape>
+	    <String CONTENT="pour éviter les autres, et apprétant le signal de nuit."
+                    HPOS="176"
+                    VPOS="809"
+                    WIDTH="476"
+                    HEIGHT="27"></String>
+          </TextLine>
+
+          
+          
+          <TextLine ID="eSc_line_dd7e9bbf"
+                    TAGREFS="LT168"
+                    BASELINE="186 859 390 861" 
+                    HPOS="186"
+                    VPOS="834"
+                    WIDTH="204"
+                    HEIGHT="31">
+            <Shape><Polygon POINTS="186 859 187 840 194 837 236 840 246 834 268 834 285 839 292 835 302 841 319 841 326 835 374 836 378 841 387 841 390 861 387 865 187 863"/></Shape>
+	    <String CONTENT="29. Matin d’Eté."
+                    HPOS="186"
+                    VPOS="834"
+                    WIDTH="204"
+                    HEIGHT="31"></String>
+          </TextLine>
+
+          
+          
+          <TextLine ID="eSc_line_f8c2b493"
+                    TAGREFS="LT168"
+                    BASELINE="191 891 655 895 743 890" 
+                    HPOS="191"
+                    VPOS="860"
+                    WIDTH="552"
+                    HEIGHT="39">
+            <Shape><Polygon POINTS="191 891 193 868 221 868 233 863 237 868 318 869 322 864 335 867 365 862 379 869 392 860 421 865 428 862 441 866 448 862 460 863 473 868 482 861 494 866 507 861 520 864 536 861 541 865 550 861 572 861 588 868 600 862 621 862 626 866 638 866 643 862 668 862 678 867 691 863 705 867 718 862 730 870 740 870 743 890 731 897 703 895 697 899 687 899 683 895 675 895 671 899 620 899 616 896 587 899 578 895 546 898 538 894 516 894 511 898 487 898 483 895 477 897 473 894 457 898 444 894 436 898 390 893 376 897 358 893 350 897 336 893 326 897 298 897 293 893 274 896 267 893 246 896 242 892 208 896 193 894"/></Shape>
+	    <String CONTENT="(Mer du Nord; au pemer pim, un (Hardenéerinet), ét."
+                    HPOS="191"
+                    VPOS="860"
+                    WIDTH="552"
+                    HEIGHT="39"></String>
+          </TextLine>
+
+          
+          
+          <TextLine ID="eSc_line_7dc24caa"
+                    TAGREFS="LT168"
+                    BASELINE="172 911 746 915" 
+                    HPOS="172"
+                    VPOS="894"
+                    WIDTH="574"
+                    HEIGHT="28">
+            <Shape><Polygon POINTS="172 911 173 894 186 897 196 894 204 898 225 894 238 898 248 894 283 898 295 894 303 898 322 899 331 895 344 899 359 895 370 899 406 899 411 896 441 899 449 895 465 900 479 896 504 900 515 896 528 900 538 896 546 899 582 896 587 900 617 896 621 901 743 896 746 915 743 921 726 917 721 922 699 917 669 922 615 921 603 916 553 917 544 921 536 917 514 921 507 916 497 920 490 916 481 920 460 919 457 916 436 916 430 920 419 916 402 920 340 920 334 916 324 920 315 915 302 918 293 915 260 915 255 918 248 916 241 919 223 915 193 915 174 918"/></Shape>
+	    <String CONTENT="tain navire de cabotage, sur la côte de la Norwège, est aborde"
+                    HPOS="172"
+                    VPOS="894"
+                    WIDTH="574"
+                    HEIGHT="28"></String>
+          </TextLine>
+
+          
+          
+          <TextLine ID="eSc_line_f5a66b85"
+                    TAGREFS="LT168"
+                    BASELINE="175 935 336 934" 
+                    HPOS="175"
+                    VPOS="916"
+                    WIDTH="161"
+                    HEIGHT="25">
+            <Shape><Polygon POINTS="175 935 176 917 187 919 192 916 196 919 201 916 207 920 216 916 243 920 248 916 254 919 264 916 268 920 273 916 282 916 287 920 311 916 316 920 333 920 336 934 314 941 297 936 288 936 282 941 251 941 244 936 230 940 217 936 194 936 189 941 177 939"/></Shape>
+	    <String CONTENT="par des pécheurs."
+                    HPOS="175"
+                    VPOS="916"
+                    WIDTH="161"
+                    HEIGHT="25"></String>
+          </TextLine>
+
+          
+          
+          <TextLine ID="eSc_line_dd30c111"
+                    TAGREFS="LT168"
+                    BASELINE="187 967 671 971" 
+                    HPOS="187"
+                    VPOS="938"
+                    WIDTH="484"
+                    HEIGHT="39">
+            <Shape><Polygon POINTS="187 967 188 944 201 941 214 948 242 948 247 943 268 938 282 940 289 947 325 949 337 938 354 943 362 938 370 946 394 949 410 939 421 943 457 939 467 943 475 939 496 947 510 940 517 947 531 942 536 945 545 941 550 945 554 941 559 946 570 942 577 948 588 950 598 943 632 943 643 951 669 951 671 971 663 977 619 977 612 974 601 977 593 973 536 977 531 972 504 972 497 977 490 973 477 977 455 971 440 976 380 970 362 975 354 975 349 970 286 975 280 970 273 974 254 970 198 974 188 970"/></Shape>
+	    <String CONTENT="40. Calme : Estre Bagholmen (Norvège)."
+                    HPOS="187"
+                    VPOS="938"
+                    WIDTH="484"
+                    HEIGHT="39"></String>
+          </TextLine>
+
+          
+          
+          <TextLine ID="eSc_line_c81fe0e7"
+                    TAGREFS="LT168"
+                    BASELINE="347 1000 727 1002" 
+                    HPOS="347"
+                    VPOS="977"
+                    WIDTH="380"
+                    HEIGHT="31">
+            <Shape><Polygon POINTS="347 1000 348 989 359 980 372 981 377 986 383 982 387 985 396 981 402 985 411 981 420 985 431 982 446 984 459 977 504 977 513 984 524 978 537 984 553 978 599 990 642 990 651 982 655 985 665 980 684 983 687 981 693 985 708 980 719 982 725 988 727 1002 723 1007 707 1003 703 1008 690 1008 685 1003 643 1003 634 1008 630 1003 591 1003 586 1008 540 1008 536 1003 527 1007 523 1003 511 1003 504 1007 470 1007 463 1003 367 1007 348 1003"/></Shape>
+	    <String CONTENT="(Apparténant à M. 1. Deliquale, à Rouen¬"
+                    HPOS="347"
+                    VPOS="977"
+                    WIDTH="380"
+                    HEIGHT="31"></String>
+          </TextLine>
+
+          
+          
+          <TextLine ID="eSc_line_c5a613e9"
+                    TAGREFS="LT168"
+                    BASELINE="186 1033 746 1034" 
+                    HPOS="186"
+                    VPOS="1007"
+                    WIDTH="560"
+                    HEIGHT="38">
+            <Shape><Polygon POINTS="186 1033 188 1015 195 1009 208 1011 214 1017 235 1017 247 1007 285 1007 296 1015 312 1017 325 1010 340 1016 355 1007 379 1011 404 1007 415 1014 448 1015 466 1008 478 1016 496 1009 508 1015 513 1010 521 1014 530 1010 540 1013 546 1007 568 1007 579 1017 591 1011 603 1015 611 1009 629 1017 666 1017 680 1010 687 1017 712 1017 724 1010 732 1010 738 1014 745 1012 746 1034 723 1044 712 1042 701 1045 694 1041 680 1043 676 1038 666 1039 660 1045 560 1045 555 1042 551 1045 521 1045 512 1037 505 1037 474 1037 465 1043 445 1042 442 1038 438 1042 428 1037 399 1037 388 1044 375 1039 358 1044 341 1040 333 1043 317 1037 298 1037 291 1041 282 1037 267 1041 262 1037 238 1037 188 1044"/></Shape>
+	    <String CONTENT="41. Pécheurs de Homards dans Bioornehiord, près"
+                    HPOS="186"
+                    VPOS="1007"
+                    WIDTH="560"
+                    HEIGHT="38"></String>
+          </TextLine>
+
+          
+          
+          <TextLine ID="eSc_line_d515cedb"
+                    TAGREFS="LT168"
+                    BASELINE="260 1058 528 1061" 
+                    HPOS="260"
+                    VPOS="1035"
+                    WIDTH="268"
+                    HEIGHT="35">
+            <Shape><Polygon POINTS="260 1058 261 1042 269 1042 278 1036 299 1042 306 1035 316 1035 328 1042 330 1039 349 1043 391 1043 398 1036 428 1036 437 1041 442 1038 447 1044 465 1044 474 1037 478 1040 492 1037 501 1042 511 1037 517 1044 525 1044 528 1061 524 1067 510 1070 495 1067 490 1070 460 1070 450 1065 433 1070 416 1064 410 1064 404 1070 377 1070 372 1064 357 1064 352 1070 331 1064 310 1069 299 1069 293 1064 261 1064"/></Shape>
+	    <String CONTENT="de Bergem (Noryége)."
+                    HPOS="260"
+                    VPOS="1035"
+                    WIDTH="268"
+                    HEIGHT="35"></String>
+          </TextLine>
+
+          
+        </TextBlock>
+        
+        <TextBlock HPOS="188"
+                   VPOS="1113"
+                   WIDTH="562"
+                   HEIGHT="104"
+                   ID="eSc_textblock_190b09f0"
+                   TAGREFS="BT464">
+          <Shape><Polygon POINTS="191 1113 652 1124 729 1148 750 1199 729 1217 201 1217 188 1206 191 1113"/></Shape>
+          
+          
+          <TextLine ID="eSc_line_32f50e20"
+                    TAGREFS="LT168"
+                    BASELINE="298 1141 608 1143" 
+                    HPOS="298"
+                    VPOS="1100"
+                    WIDTH="310"
+                    HEIGHT="51">
+            <Shape><Polygon POINTS="298 1141 300 1115 307 1111 320 1115 323 1111 328 1115 342 1109 355 1110 370 1100 384 1104 392 1100 410 1104 419 1100 440 1104 451 1101 462 1107 468 1103 475 1106 489 1101 520 1101 544 1116 606 1116 608 1143 605 1151 589 1151 575 1144 557 1144 552 1147 530 1144 516 1151 492 1151 483 1144 450 1146 441 1143 388 1143 380 1151 353 1151 342 1144 316 1151 302 1143 299 1144"/></Shape>
+	    <String CONTENT="BEVTABOLE (Lopis)."
+                    HPOS="298"
+                    VPOS="1100"
+                    WIDTH="310"
+                    HEIGHT="51"></String>
+          </TextLine>
+
+          
+          
+          <TextLine ID="eSc_line_60af8759"
+                    TAGREFS="LT168"
+                    BASELINE="343 1175 578 1177" 
+                    HPOS="343"
+                    VPOS="1154"
+                    WIDTH="235"
+                    HEIGHT="42">
+            <Shape><Polygon POINTS="343 1175 344 1160 351 1155 356 1160 375 1154 383 1160 397 1160 403 1155 417 1160 425 1160 430 1156 451 1160 458 1154 497 1154 503 1157 517 1154 524 1161 542 1161 549 1155 555 1157 559 1154 575 1161 578 1177 574 1196 555 1188 536 1196 472 1196 464 1189 450 1191 434 1187 416 1193 404 1188 396 1192 379 1187 370 1191 366 1187 344 1190"/></Shape>
+	    <String CONTENT="A Paris, rue Dielle, 2e."
+                    HPOS="343"
+                    VPOS="1154"
+                    WIDTH="235"
+                    HEIGHT="42"></String>
+          </TextLine>
+
+          
+          
+          <TextLine ID="eSc_line_641d1bf5"
+                    TAGREFS="LT168"
+                    BASELINE="195 1208 398 1210" 
+                    HPOS="195"
+                    VPOS="1184"
+                    WIDTH="203"
+                    HEIGHT="37">
+            <Shape><Polygon POINTS="195 1208 197 1186 228 1190 241 1184 255 1184 282 1190 307 1185 323 1191 331 1185 343 1191 350 1185 364 1190 378 1185 387 1191 396 1191 398 1210 396 1221 371 1216 297 1221 286 1218 251 1218 244 1215 195 1220"/></Shape>
+	    <String CONTENT="2, Vue de Calais."
+                    HPOS="195"
+                    VPOS="1184"
+                    WIDTH="203"
+                    HEIGHT="37"></String>
+          </TextLine>
+
+          
+        </TextBlock>
+        
+        <TextBlock HPOS="160"
+                   VPOS="187"
+                   WIDTH="611"
+                   HEIGHT="1047"
+                   ID="eSc_textblock_2551dbd7"
+                   TAGREFS="BT458">
+          <Shape><Polygon POINTS="685 187 743 187 760 208 750 212 760 215 753 385 767 590 757 635 771 762 760 1213 715 1234 188 1224 174 1171 181 1099 167 1067 160 938 160 685 174 632 163 445 174 407 191 402 167 329 167 261 174 226 222 212 174 208 685 187"/></Shape>
+          
+        </TextBlock>
+        
+
+        
+      </PrintSpace>
+    </Page>
+  </Layout>
+</alto>

--- a/test_contenu_entrées.py
+++ b/test_contenu_entrées.py
@@ -1,0 +1,31 @@
+from shapely.geometry import Polygon
+""" Vérifier que les blocks entrées sont bien construits => test?
+Idée: récupérer les coordonnées des entrées textblock et les coordonnées des lignes et les associer
+pour chaque TextBlock(entrée) get coordonnées
+    pour TextBlock main: 
+        pour chaque ligne
+            get coordonnées
+            si coordonnées lignes dans coordonnées textligne alors ajouter à liste
+
+
+for el in document.xpath("//alto:TextBlock[@TAGREFS='TYPE_7']", namespaces=NS):
+    # récupérer les coordonnées
+    coord_V_block = int(el.xpath("@VPOS")[0])
+    coord_H_block = int(el.xpath("@HPOS")[0])
+    coord_width_block = int(el.xpath("@WIDTH")[0])
+    coord_height_block = int(el.xpath("@HEIGHT")[0])
+    # créer le polygone correspondant
+    coord_block= [(coord_V_block, coord_H_block),(coord_V_block, coord_H_block + coord_width_block), (coord_V_block + coord_height_block, coord_H_block), (coord_V_block + coord_height_block, coord_H_block + coord_width_block)]
+    poly_block = Polygon(coord_block)
+    for ligne in document.xpath("//alto:TextLine", namespaces=NS):
+        # récupérer les coordonnées de la ligne
+        coord_V_line = int(ligne.xpath("@VPOS")[0])
+        coord_H_line = int(ligne.xpath("@HPOS")[0])
+        coord_width_line = int(ligne.xpath("@WIDTH")[0])
+        coord_height_line = int(ligne.xpath("@HEIGHT")[0])
+        #créer le polygone correspondant
+        coord_line = [(coord_V_line, coord_H_line), (coord_V_line, coord_H_line + coord_width_line), (coord_V_line + coord_height_line, coord_H_line), (coord_V_line + coord_height_line, coord_H_line + coord_width_line)]
+        poly_line = Polygon(coord_line)
+        if poly_block.contains(poly_line):
+            print('ok')
+"""


### PR DESCRIPTION
- création d'un fichier run pivot lançant les différentes fonctions
- création d'un fichier extractionCatSimple qui permet d'extraire les données contenues dans les entrées des Catalogues de typologie simple c'est à dire où chaque donnée est contenu dans une ligne séparée à l'instar des catalogues de Rouen 1850-1880
- création d'un fichier test contenant un début de travail pour la vérification de l'aspect général de l'alto afin de savoir si l'on peut utiliser les entrées du fichier
- création du fichier création Teiheader pour réaliser un travail similaire au programme proposé par Claire de récupération des données
- création d'un dossier contenant les données de test